### PR TITLE
why are these cheat protected?

### DIFF
--- a/engine/client/ref_common.c
+++ b/engine/client/ref_common.c
@@ -588,7 +588,7 @@ qboolean R_Init( void )
 
 	// cvars that are expected to exist
 	Cvar_Get( "r_speeds", "0", FCVAR_ARCHIVE, "shows renderer speeds" );
-	Cvar_Get( "r_fullbright", "0", FCVAR_CHEAT, "disable lightmaps, get fullbright for entities" );
+	Cvar_Get( "r_fullbright", "0", 0, "disable lightmaps, get fullbright for entities" );
 	Cvar_Get( "r_norefresh", "0", 0, "disable 3D rendering (use with caution)" );
 	Cvar_Get( "r_dynamic", "1", FCVAR_ARCHIVE, "allow dynamic lighting (dlights, lightstyles)" );
 	Cvar_Get( "r_lightmap", "0", FCVAR_CHEAT, "lightmap debugging tool" );
@@ -605,7 +605,7 @@ qboolean R_Init( void )
 
 	// cvars that are expected to exist by client.dll
 	// refdll should just get pointer to them
-	Cvar_Get( "r_drawentities", "1", FCVAR_CHEAT, "render entities" );
+	Cvar_Get( "r_drawentities", "1", 0, "render entities" );
 	Cvar_Get( "cl_himodels", "1", FCVAR_ARCHIVE, "draw high-resolution player models in multiplayer" );
 
 	// cvars are created, execute video config


### PR DESCRIPTION
removes cheat protection for `r_fullbright` and `r_drawentities`